### PR TITLE
Add watch for building documentation assets

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "watch": "npm-run-all clean -p css:watch",
     "build": "npm-run-all clean css:dev css:build",
     "build:docs": "webpack --config html/webpack.config.js",
+    "build:docs:watch": "webpack --config html/webpack.config.js --watch",
     "build:docs:production": "webpack --config html/webpack.config.js --mode=production",
     "clean": "rimraf static/css/*",
     "css:dev": "sass src/scss/main.scss:static/css/main.css --load-path=node_modules --no-source-map --style=compressed",


### PR DESCRIPTION
Now you can run `npm run build:docs:watch`. This will build and copy the needed assets for the html folder.