### PR TITLE
Fix: Removes general use of centering only children on pages

### DIFF
--- a/scss/manon/manon-components.scss
+++ b/scss/manon/manon-components.scss
@@ -27,7 +27,6 @@
 @use "@minvws/manon/layout-column-3";
 @use "@minvws/manon/layout-column-4";
 @use "@minvws/manon/layout-centered";
-@use "@minvws/manon/center-only-child";
 
 /* Main */
 @use "@minvws/manon/main";


### PR DESCRIPTION
Fix: Removes general use of centering only children on pages