### PR TITLE
Set sidemenu content container variables

### DIFF
--- a/scss/manon/sidemenu.scss
+++ b/scss/manon/sidemenu.scss
@@ -9,4 +9,10 @@
   /* content on the button when the menu is expanded */
   --sidemenu-expanded-button-icon: var(--icon-close);
   --sidemenu-button-icon-font-size: 0.7rem;
+
+  /* content */
+  --sidemenu-content-container-padding-top: var(--page-whitespace-top);
+  --sidemenu-content-container-padding-right: var(--page-whitespace-right);
+  --sidemenu-content-container-padding-bottom: var(--page-whitespace-bottom);
+  --sidemenu-content-container-padding-left: var(--page-whitespace-left);
 }


### PR DESCRIPTION
No padding is needed, can be set to 0 or can follow the page-whitespace variables.