### PR TITLE
Fix: Update default header navigation link text color

### DIFF
--- a/scss/manon/header-navigation.scss
+++ b/scss/manon/header-navigation.scss
@@ -37,7 +37,7 @@
   --header-navigation-link-padding-right: 0.5rem;
   --header-navigation-link-padding-left: 0.5rem;
   --header-navigation-link-background-color: transparent;
-  --header-navigation-link-text-color: var(--ruby-red-tint-1-text-color);
+  --header-navigation-link-text-color: var(--ruby-red-text-color);
   --header-navigation-link-min-height: 3rem;
 
   /* Link Icon */


### PR DESCRIPTION
The color `--ruby-red-tint-1-text-color` is for the active button. The button text color should be the `--ruby-red-text-color` because the header navigation bar is ruby red.

`--ruby-red-tint-1-text-color` is black.
`--ruby-red-text-color` is white.

![image](https://github.com/minvws/nl-rdo-rijksoverheid-ui-theme/assets/1367665/df004202-e2e1-483c-886b-b43d8d624703)
