### PR TITLE
Feat/improve-custom-font-loading

### DIFF
--- a/scss/fonts/ro-icons/ro-icons.scss
+++ b/scss/fonts/ro-icons/ro-icons.scss
@@ -5,7 +5,7 @@
   font-family: "RO Icons";
   font-weight: normal;
   font-style: normal;
-  font-display: fallback;
+  font-display: var(--text-icon-font-display, block);
   src:
     url("#{$ro-font-path}/ro-icons/ro-icons-3.6.woff2") format("woff2"),
     url("#{$ro-font-path}/ro-icons/ro-icons-3.6.woff") format("woff"),

--- a/scss/fonts/ro-sans-web/ro-sans-web.scss
+++ b/scss/fonts/ro-sans-web/ro-sans-web.scss
@@ -7,7 +7,7 @@
   font-family: "RO Sans Web";
   font-weight: normal;
   font-style: normal;
-  font-display: fallback;
+  font-display: var(--text-body-font-display, swap);
   src:
     url("#{$ro-font-path}/ro-sans-web/RO-SansWebText-Regular.woff2") format("woff2"),
     url("#{$ro-font-path}/ro-sans-web/RO-SansWebText-Regular.woff") format("woff"),
@@ -18,7 +18,7 @@
   font-family: "RO Sans Web";
   font-weight: normal;
   font-style: italic;
-  font-display: fallback;
+  font-display: var(--text-body-font-display, swap);
   src:
     url("#{$ro-font-path}/ro-sans-web/RO-SansWebText-Italic.woff2") format("woff2"),
     url("#{$ro-font-path}/ro-sans-web/RO-SansWebText-Italic.woff") format("woff"),
@@ -30,7 +30,7 @@
   font-family: "RO Sans Web";
   font-weight: bold;
   font-style: normal;
-  font-display: fallback;
+  font-display: var(--text-body-font-display, swap);
   src:
     url("#{$ro-font-path}/ro-sans-web/RO-SansWebText-Bold.woff2") format("woff2"),
     url("#{$ro-font-path}/ro-sans-web/RO-SansWebText-Bold.woff") format("woff"),

--- a/scss/fonts/ro-serif-web/ro-serif-web.scss
+++ b/scss/fonts/ro-serif-web/ro-serif-web.scss
@@ -7,7 +7,7 @@
   font-family: "RO Serif Web";
   font-weight: normal;
   font-style: normal;
-  font-display: fallback;
+  font-display: var(--text-magazine-font-display, fallback);
   src:
     url("#{$ro-font-path}/ro-serif-web/RO-SerifWeb-Regular.woff2") format("woff2"),
     url("#{$ro-font-path}/ro-serif-web/RO-SerifWeb-Regular.woff") format("woff"),
@@ -18,7 +18,7 @@
   font-family: "RO Serif Web";
   font-weight: normal;
   font-style: italic;
-  font-display: fallback;
+  font-display: var(--text-magazine-font-display, fallback);
   src:
     url("#{$ro-font-path}/ro-serif-web/RO-SerifWeb-Italic.woff2") format("woff2"),
     url("#{$ro-font-path}/ro-serif-web/RO-SerifWeb-Italic.woff") format("woff"),
@@ -30,7 +30,7 @@
   font-family: "RO Serif Web";
   font-weight: bold;
   font-style: normal;
-  font-display: fallback;
+  font-display: var(--text-magazine-font-display, fallback);
   src:
     url("#{$ro-font-path}/ro-serif-web/RO-SerifWeb-Bold.woff2") format("woff2"),
     url("#{$ro-font-path}/ro-serif-web/RO-SerifWeb-Bold.woff") format("woff"),


### PR DESCRIPTION
This pull request includes a change to a better font loading strategy. Using `font-display: swap;` there's a higher possibility and duration of FOUT. To reduce both, we should use `font-display: fallback;`. For more info, check: [https://css-tricks.com/almanac/properties/f/font-display](https://css-tricks.com/almanac/properties/f/font-display).