### PR TITLE
Added font license exemption

### DIFF
--- a/fonts/LICENSE.md
+++ b/fonts/LICENSE.md
@@ -1,0 +1,5 @@
+The open source license does NOT apply to files in this directory.
+
+Bij regeling van 16 juni 2008 (Stcrt. 2008, nr. 115) heeft de Staat der Nederlanden (Ministerie van Algemene Zaken) een auteursrechtelijk voorbehoud gemaakt, als bedoeld in artikel 15b van de Auteurswet 1912, met betrekking tot het gebruik en de toepassing van het ontwerp van het voor de Rijksoverheid algemeen geldende Rijkslogo en de huisstijl, waaronder begrepen het gebruik van de lettertypes RijksoverheidSerif en RijksoverheidSans.
+
+Genoemd voorbehoud is niet van toepassing op partijen aan wie door of vanwege de Rijksoverheid het Rijkslogo en de huisstijl ter beschikking is gesteld met het oog op het gebruik bij de uitoefening van werkzaamheden of diensten in opdracht van de Rijksoverheid. Ieder gebruik in welke vorm of wijze, hetzij elektronisch, mechanisch, door fotokopieën, opnamen of enige andere manier is verboden tenzij er voorafgaand schriftelijke toestemming van de Rijksoverheid is verkregen. Voor toestemming kunt u zich wenden tot de Rijksvoorlichtingsdienst.


### PR DESCRIPTION
Bij regeling van 16 juni 2008 (Stcrt. 2008, nr. 115) heeft de Staat der Nederlanden (Ministerie van Algemene Zaken) een auteursrechtelijk voorbehoud gemaakt, als bedoeld in artikel 15b van de Auteurswet 1912, met betrekking tot het gebruik en de toepassing van het ontwerp van het voor de Rijksoverheid algemeen geldende Rijkslogo en de huisstijl, waaronder begrepen het gebruik van de lettertypes RijksoverheidSerif en RijksoverheidSans.

Genoemd voorbehoud is niet van toepassing op partijen aan wie door of vanwege de Rijksoverheid het Rijkslogo en de huisstijl ter beschikking is gesteld met het oog op het gebruik bij de uitoefening van werkzaamheden of diensten in opdracht van de Rijksoverheid. Ieder gebruik in welke vorm of wijze, hetzij elektronisch, mechanisch, door fotokopieën, opnamen of enige andere manier is verboden tenzij er voorafgaand schriftelijke toestemming van de Rijksoverheid is verkregen. Voor toestemming kunt u zich wenden tot de Rijksvoorlichtingsdienst.
