### PR TITLE
fix: font-display default values

### DIFF
--- a/scss/fonts/ro-sans-web/ro-sans-web.scss
+++ b/scss/fonts/ro-sans-web/ro-sans-web.scss
@@ -7,7 +7,7 @@
   font-family: "RO Sans Web";
   font-weight: normal;
   font-style: normal;
-  font-display: var(--text-body-font-display, swap);
+  font-display: var(--text-body-font-display, fallback);
   src:
     url("#{$ro-font-path}/ro-sans-web/RO-SansWebText-Regular.woff2") format("woff2"),
     url("#{$ro-font-path}/ro-sans-web/RO-SansWebText-Regular.woff") format("woff"),
@@ -18,7 +18,7 @@
   font-family: "RO Sans Web";
   font-weight: normal;
   font-style: italic;
-  font-display: var(--text-body-font-display, swap);
+  font-display: var(--text-body-font-display, fallback);
   src:
     url("#{$ro-font-path}/ro-sans-web/RO-SansWebText-Italic.woff2") format("woff2"),
     url("#{$ro-font-path}/ro-sans-web/RO-SansWebText-Italic.woff") format("woff"),
@@ -30,7 +30,7 @@
   font-family: "RO Sans Web";
   font-weight: bold;
   font-style: normal;
-  font-display: var(--text-body-font-display, swap);
+  font-display: var(--text-body-font-display, fallback);
   src:
     url("#{$ro-font-path}/ro-sans-web/RO-SansWebText-Bold.woff2") format("woff2"),
     url("#{$ro-font-path}/ro-sans-web/RO-SansWebText-Bold.woff") format("woff"),

--- a/scss/fonts/ro-serif-web/ro-serif-web.scss
+++ b/scss/fonts/ro-serif-web/ro-serif-web.scss
@@ -7,7 +7,7 @@
   font-family: "RO Serif Web";
   font-weight: normal;
   font-style: normal;
-  font-display: var(--text-magazine-font-display, fallback);
+  font-display: var(--text-magazine-font-display, swap);
   src:
     url("#{$ro-font-path}/ro-serif-web/RO-SerifWeb-Regular.woff2") format("woff2"),
     url("#{$ro-font-path}/ro-serif-web/RO-SerifWeb-Regular.woff") format("woff"),
@@ -18,7 +18,7 @@
   font-family: "RO Serif Web";
   font-weight: normal;
   font-style: italic;
-  font-display: var(--text-magazine-font-display, fallback);
+  font-display: var(--text-magazine-font-display, swap);
   src:
     url("#{$ro-font-path}/ro-serif-web/RO-SerifWeb-Italic.woff2") format("woff2"),
     url("#{$ro-font-path}/ro-serif-web/RO-SerifWeb-Italic.woff") format("woff"),
@@ -30,7 +30,7 @@
   font-family: "RO Serif Web";
   font-weight: bold;
   font-style: normal;
-  font-display: var(--text-magazine-font-display, fallback);
+  font-display: var(--text-magazine-font-display, swap);
   src:
     url("#{$ro-font-path}/ro-serif-web/RO-SerifWeb-Bold.woff2") format("woff2"),
     url("#{$ro-font-path}/ro-serif-web/RO-SerifWeb-Bold.woff") format("woff"),


### PR DESCRIPTION
As discussed in https://github.com/minvws/nl-rdo-rijksoverheid-ui-theme/pull/283#issuecomment-1794692532:

> According to [https://developer.chrome.com/blog/font-display/](https://developer.chrome.com/blog/font-display/) if we want to be very specific then headings should load fonts using `swap` and paragraphs should load fonts using `fallback`. We

I got this the wrong way around in my update (e64e9b3) to #283. This PR fixes that mistake.
