### PR TITLE
fix: add root .scss files to package

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "css",
     "fonts",
     "img",
-    "scss"
+    "scss",
+    "*.scss"
   ],
   "scripts": {
     "dev": "npm-run-all clean build:docs",


### PR DESCRIPTION
I forgot to add the `.scss` files at the root of the project to the package's `files` list in #306.