### PR TITLE
chore(visual-testing): remove screenshot artifacts if not dependabot

### DIFF
--- a/.github/workflows/visual-testing.yml
+++ b/.github/workflows/visual-testing.yml
@@ -95,7 +95,7 @@ jobs:
             screenshots
           retention-days: 7
       - name: Delete screenshots artifact
-        if: always()
+        if: (always() && github.actor != 'dependabot[bot]')
         uses: geekyeggo/delete-artifact@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The GitHub token on dependabot PR's does not have rights to remove artifacts.

So exclude this step when the PR is created by dependabot.