### PR TITLE
ci: change npm audit-level to "high"

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -5,6 +5,9 @@ inputs:
   NODE_AUTH_TOKEN:
     description: Read-only token git GitHub Package Registry
     required: true
+  audit-level:
+    description: npm audit-level <info|low|moderate|high|ciritical|none>
+    default: "high"
 
 runs:
   using: "composite"
@@ -17,7 +20,7 @@ runs:
         registry-url: "https://npm.pkg.github.com"
     - name: Audit dependencies
       shell: sh
-      run: npm audit --audit-level=high
+      run: npm audit --audit-level=${{ inputs.audit-level }}
     - name: Install dependencies
       shell: sh
       run: npm ci --ignore-scripts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,19 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  audit:
+    name: Audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Audit dependencies
+        uses: ./.github/actions/setup
+        with:
+          NODE_AUTH_TOKEN: ${{ secrets.REPO_READ_ONLY_TOKEN }}
+          audit-level: moderate
+
   lint:
     name: Lint
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR changes our CI's composite setup action's default `npm audit` level to "high". This is to avoid moderate severity CVE's like CVE-2024-4067 (which as far as I can tell is not even correct!) from causing all our CI jobs to fail without even running.

Vulnerabilities with severity level "high" or "critical" will still prevent all CI jobs from running.

A new "audit" job with the normal level ("moderate") keeps us aware of vulnerabilities and gives us a chance to look into whether or not they're applicable to our situation without preventing us from merging or releasing (if we deem it reasonable):

<img alt="Screenshot of CI result. Audit failed. The other two jobs were successful." src="https://github.com/user-attachments/assets/24552244-065c-4752-bd16-9a9a6b62b5ac" alt="" height="165" />
