### PR TITLE
fix: footer navigation icon position

### DIFF
--- a/scss/manon/navigation.scss
+++ b/scss/manon/navigation.scss
@@ -64,13 +64,11 @@ nav {
     &:hover::before {
       text-decoration-color: transparent;
       position: absolute;
-      top: 0;
+      top: 0.4rem;
       left: 0;
       display: inline-flex;
       align-items: center;
       justify-self: center;
-      height: 100%;
-      line-height: 1;
     }
   }
 }


### PR DESCRIPTION
Before:

![image](https://github.com/user-attachments/assets/a710f0c1-45db-4dff-aeb7-677f1538f4a8)

After:

![image](https://github.com/user-attachments/assets/c24f2638-5603-47f3-9680-156cad6e25f9)

