### PR TITLE
fix!: provide default values for layout-authentication-padding

### DIFF
--- a/scss/manon/layout-authentication.scss
+++ b/scss/manon/layout-authentication.scss
@@ -2,4 +2,8 @@
 
 :root {
   --layout-authentication-max-width: 50rem;
+  --layout-authentication-padding-top: var(--content-padding-top);
+  --layout-authentication-padding-right: var(--content-padding-right);
+  --layout-authentication-padding-bottom: var(--content-padding-bottom);
+  --layout-authentication-padding-left: var(--content-padding-left);
 }


### PR DESCRIPTION
Fills layout authentication variables in line with other layout settings to resolve inconsistencies.

Fixes #455

BREAKING CHANGE: applications that use `layout-authentication` and set custom `--section-padding-{top,bottom}` will now need to add the same overrides for `--layout-authentication-padding-{top,bottom}`.