### PR TITLE
ci: capture visual test screenshots in parallel

### DIFF
--- a/visual-test/Dockerfile
+++ b/visual-test/Dockerfile
@@ -7,4 +7,6 @@ ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/firefox
 RUN apk add --update-cache firefox font-dejavu \
   && rm -rf /var/cache/apk/*
 
+RUN echo 'user_pref("layout.css.visited_links_enabled", false);' >> /usr/lib/firefox/defaults/pref/prefs.js
+
 WORKDIR /src

--- a/visual-test/backstop-config.js
+++ b/visual-test/backstop-config.js
@@ -32,8 +32,6 @@ export const createBackstopConfig = ({ port, files }) => ({
     args: ["--no-sandbox"],
     protocol: "webDriverBiDi",
   },
-  // avoid race conditions:
-  asyncCaptureLimit: 1,
   // reduce this if memory usage is too high
   asyncCompareLimit: 50,
 });


### PR DESCRIPTION
Tweak visual test runner to allow parallelism. Should slightly decrease test runtime in multi-core environments.