### PR TITLE
ci: fix CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,4 @@
-# NB: the LAST match takes precedence.
-# See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax
+# The LAST matching line takes precedence.
 
 * @minvws/rdo-manon-codeowners
 .github/CODEOWNERS @minvws/irealisatie-operations


### PR DESCRIPTION
Fix the order of the rules in the `CODEOWNERS` file and add a comment about precedence.

This PR was originally just to add the rules, and **was** initially superseded by #527, but since that introduced the rules in the incorrect order I've "recycled" this PR to fix it.