### PR TITLE
fix side menu list item icon alignment

### DIFF
--- a/scss/manon/navigation.scss
+++ b/scss/manon/navigation.scss
@@ -64,10 +64,10 @@ nav {
     &:hover::before {
       text-decoration-color: transparent;
       position: absolute;
-      top: 0;
+      top: 0.25rem;
       left: 0;
       display: inline-flex;
-      align-items: center;
+      align-items: flex-start;
       justify-self: center;
       height: 100%;
       line-height: 1;


### PR DESCRIPTION
Fixes side menu list item icon alignment

Before: 
![Screenshot 2025-03-11 at 17 18 13](https://github.com/user-attachments/assets/93f3265d-01a1-4087-b650-52584c7ccdbb)

After: 
![Screenshot 2025-03-11 at 17 18 22](https://github.com/user-attachments/assets/7656ed44-025c-4d53-98b5-c938ecbe669f)
