### PR TITLE
fix: include *.license files in npm package

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -4,8 +4,3 @@ version = 1
 path = "**"
 SPDX-FileCopyrightText = "iRealisatie - Ministerie van Volksgezondheid, Welzijn en Sport"
 SPDX-License-Identifier = "EUPL-1.2"
-
-[[annotations]]
-path = ["fonts/**", "img/**"]
-SPDX-FileCopyrightText = "Ministry of General Affairs of the Netherlands"
-SPDX-License-Identifier = "LicenseRef-Rijkshuisstijl"

--- a/fonts/ro-icons-extended/ro-icons-extended-3.6.svg.license
+++ b/fonts/ro-icons-extended/ro-icons-extended-3.6.svg.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: © Ministry of General Affairs of the Netherlands
+SPDX-License-Identifier: LicenseRef-Rijkshuisstijl

--- a/fonts/ro-icons-extended/ro-icons-extended-3.6.ttf.license
+++ b/fonts/ro-icons-extended/ro-icons-extended-3.6.ttf.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: © Ministry of General Affairs of the Netherlands
+SPDX-License-Identifier: LicenseRef-Rijkshuisstijl

--- a/fonts/ro-icons-extended/ro-icons-extended-3.6.woff.license
+++ b/fonts/ro-icons-extended/ro-icons-extended-3.6.woff.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: © Ministry of General Affairs of the Netherlands
+SPDX-License-Identifier: LicenseRef-Rijkshuisstijl

--- a/fonts/ro-icons-extended/ro-icons-extended-3.6.woff2.license
+++ b/fonts/ro-icons-extended/ro-icons-extended-3.6.woff2.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: © Ministry of General Affairs of the Netherlands
+SPDX-License-Identifier: LicenseRef-Rijkshuisstijl

--- a/fonts/ro-icons-light/ro-icons-light.svg.license
+++ b/fonts/ro-icons-light/ro-icons-light.svg.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: © Ministry of General Affairs of the Netherlands
+SPDX-License-Identifier: LicenseRef-Rijkshuisstijl

--- a/fonts/ro-icons-light/ro-icons-light.ttf.license
+++ b/fonts/ro-icons-light/ro-icons-light.ttf.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: © Ministry of General Affairs of the Netherlands
+SPDX-License-Identifier: LicenseRef-Rijkshuisstijl

--- a/fonts/ro-icons-light/ro-icons-light.woff.license
+++ b/fonts/ro-icons-light/ro-icons-light.woff.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: © Ministry of General Affairs of the Netherlands
+SPDX-License-Identifier: LicenseRef-Rijkshuisstijl

--- a/fonts/ro-icons-light/ro-icons-light.woff2.license
+++ b/fonts/ro-icons-light/ro-icons-light.woff2.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: © Ministry of General Affairs of the Netherlands
+SPDX-License-Identifier: LicenseRef-Rijkshuisstijl

--- a/fonts/ro-sans-web/RO-SansWebText-Bold.ttf.license
+++ b/fonts/ro-sans-web/RO-SansWebText-Bold.ttf.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: © Ministry of General Affairs of the Netherlands
+SPDX-License-Identifier: LicenseRef-Rijkshuisstijl

--- a/fonts/ro-sans-web/RO-SansWebText-Bold.woff.license
+++ b/fonts/ro-sans-web/RO-SansWebText-Bold.woff.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: © Ministry of General Affairs of the Netherlands
+SPDX-License-Identifier: LicenseRef-Rijkshuisstijl

--- a/fonts/ro-sans-web/RO-SansWebText-Bold.woff2.license
+++ b/fonts/ro-sans-web/RO-SansWebText-Bold.woff2.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: © Ministry of General Affairs of the Netherlands
+SPDX-License-Identifier: LicenseRef-Rijkshuisstijl

--- a/fonts/ro-sans-web/RO-SansWebText-Italic.ttf.license
+++ b/fonts/ro-sans-web/RO-SansWebText-Italic.ttf.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: © Ministry of General Affairs of the Netherlands
+SPDX-License-Identifier: LicenseRef-Rijkshuisstijl

--- a/fonts/ro-sans-web/RO-SansWebText-Italic.woff.license
+++ b/fonts/ro-sans-web/RO-SansWebText-Italic.woff.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: © Ministry of General Affairs of the Netherlands
+SPDX-License-Identifier: LicenseRef-Rijkshuisstijl

--- a/fonts/ro-sans-web/RO-SansWebText-Italic.woff2.license
+++ b/fonts/ro-sans-web/RO-SansWebText-Italic.woff2.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: © Ministry of General Affairs of the Netherlands
+SPDX-License-Identifier: LicenseRef-Rijkshuisstijl

--- a/fonts/ro-sans-web/RO-SansWebText-Regular.ttf.license
+++ b/fonts/ro-sans-web/RO-SansWebText-Regular.ttf.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: © Ministry of General Affairs of the Netherlands
+SPDX-License-Identifier: LicenseRef-Rijkshuisstijl

--- a/fonts/ro-sans-web/RO-SansWebText-Regular.woff.license
+++ b/fonts/ro-sans-web/RO-SansWebText-Regular.woff.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: © Ministry of General Affairs of the Netherlands
+SPDX-License-Identifier: LicenseRef-Rijkshuisstijl

--- a/fonts/ro-sans-web/RO-SansWebText-Regular.woff2.license
+++ b/fonts/ro-sans-web/RO-SansWebText-Regular.woff2.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: © Ministry of General Affairs of the Netherlands
+SPDX-License-Identifier: LicenseRef-Rijkshuisstijl

--- a/fonts/ro-serif-web/RO-SerifWeb-Bold.ttf.license
+++ b/fonts/ro-serif-web/RO-SerifWeb-Bold.ttf.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: © Ministry of General Affairs of the Netherlands
+SPDX-License-Identifier: LicenseRef-Rijkshuisstijl

--- a/fonts/ro-serif-web/RO-SerifWeb-Bold.woff.license
+++ b/fonts/ro-serif-web/RO-SerifWeb-Bold.woff.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: © Ministry of General Affairs of the Netherlands
+SPDX-License-Identifier: LicenseRef-Rijkshuisstijl

--- a/fonts/ro-serif-web/RO-SerifWeb-Bold.woff2.license
+++ b/fonts/ro-serif-web/RO-SerifWeb-Bold.woff2.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: © Ministry of General Affairs of the Netherlands
+SPDX-License-Identifier: LicenseRef-Rijkshuisstijl

--- a/fonts/ro-serif-web/RO-SerifWeb-Italic.ttf.license
+++ b/fonts/ro-serif-web/RO-SerifWeb-Italic.ttf.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: © Ministry of General Affairs of the Netherlands
+SPDX-License-Identifier: LicenseRef-Rijkshuisstijl

--- a/fonts/ro-serif-web/RO-SerifWeb-Italic.woff.license
+++ b/fonts/ro-serif-web/RO-SerifWeb-Italic.woff.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: © Ministry of General Affairs of the Netherlands
+SPDX-License-Identifier: LicenseRef-Rijkshuisstijl

--- a/fonts/ro-serif-web/RO-SerifWeb-Italic.woff2.license
+++ b/fonts/ro-serif-web/RO-SerifWeb-Italic.woff2.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: © Ministry of General Affairs of the Netherlands
+SPDX-License-Identifier: LicenseRef-Rijkshuisstijl

--- a/fonts/ro-serif-web/RO-SerifWeb-Regular.ttf.license
+++ b/fonts/ro-serif-web/RO-SerifWeb-Regular.ttf.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: © Ministry of General Affairs of the Netherlands
+SPDX-License-Identifier: LicenseRef-Rijkshuisstijl

--- a/fonts/ro-serif-web/RO-SerifWeb-Regular.woff.license
+++ b/fonts/ro-serif-web/RO-SerifWeb-Regular.woff.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: © Ministry of General Affairs of the Netherlands
+SPDX-License-Identifier: LicenseRef-Rijkshuisstijl

--- a/fonts/ro-serif-web/RO-SerifWeb-Regular.woff2.license
+++ b/fonts/ro-serif-web/RO-SerifWeb-Regular.woff2.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: © Ministry of General Affairs of the Netherlands
+SPDX-License-Identifier: LicenseRef-Rijkshuisstijl

--- a/img/favicon.ico.license
+++ b/img/favicon.ico.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: © Ministry of General Affairs of the Netherlands
+SPDX-License-Identifier: LicenseRef-Rijkshuisstijl

--- a/img/notification_icons.svg.license
+++ b/img/notification_icons.svg.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: © Ministry of General Affairs of the Netherlands
+SPDX-License-Identifier: LicenseRef-Rijkshuisstijl

--- a/img/notification_icons_dark.svg.license
+++ b/img/notification_icons_dark.svg.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: © Ministry of General Affairs of the Netherlands
+SPDX-License-Identifier: LicenseRef-Rijkshuisstijl

--- a/img/notification_icons_light.svg.license
+++ b/img/notification_icons_light.svg.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: © Ministry of General Affairs of the Netherlands
+SPDX-License-Identifier: LicenseRef-Rijkshuisstijl

--- a/img/ro-logo-full.svg.license
+++ b/img/ro-logo-full.svg.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: © Ministry of General Affairs of the Netherlands
+SPDX-License-Identifier: LicenseRef-Rijkshuisstijl

--- a/img/ro-logo.svg.license
+++ b/img/ro-logo.svg.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: © Ministry of General Affairs of the Netherlands
+SPDX-License-Identifier: LicenseRef-Rijkshuisstijl


### PR DESCRIPTION
This PR:
- Moves the copyright and license declaration of all Rijkshuisstijl files to individual `*.license` files.
- Applies the advice from [How and why to properly write copyright statements in your code](https://matija.suklje.name/how-and-why-to-properly-write-copyright-statements-in-your-code) (found via the [REUSE.software FAQ](https://reuse.software/faq/)) about using `SPDX-FileCopyrightText` and the © symbol.

Result:
```shell
$ tar zxf minvws-nl-rdo-rijksoverheid-ui-theme-0.0.0.tgz

$ cd package

$ docker run --rm --volume $(pwd):/data fsfe/reuse lint
# SUMMARY

* Bad licenses: 0
* Deprecated licenses: 0
* Licenses without file extension: 0
* Missing licenses: 0
* Unused licenses: 0
* Used licenses: LicenseRef-Rijkshuisstijl, EUPL-1.2
* Read errors: 0
* Files with copyright information: 132 / 132
* Files with license information: 132 / 132

Congratulations! Your project is compliant with version 3.3 of the REUSE Specification :-)
```