### PR TITLE
chore: update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /node_modules
 /css
+/*.tgz


### PR DESCRIPTION
Update `.gitignore` to remove outdated entries and environment specific entries (which should be in the user's `~/.gitignore`) and add and entry for `/*.tgz` (`npm pack` output).
