### PR TITLE
Fix: typo in `package.json` peerDepencency to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "visual:reference": "npm run build && npm run visual:pull && docker compose -f visual-test/docker-compose.yml run --rm reference",
     "visual:pull": "docker compose -f visual-test/docker-compose.yml --profile one-off pull"
   },
-  "peerDepencency": {
+  "peerDependencies": {
     "@minvws/manon": "^17.0.0-beta.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR Fixes a typo in `package.json` **peerDepencency** should be **peerDependencies**