### PR TITLE
chore: fix typo in `audit-level` description in `action.yml`

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -6,7 +6,7 @@ inputs:
     description: Read-only token for GitHub Package Registry
     required: true
   audit-level:
-    description: npm audit-level <info|low|moderate|high|ciritical|none>
+    description: npm audit-level <info|low|moderate|high|critical|none>
     default: "high"
 
 runs:


### PR DESCRIPTION
This PR fixes a typo in `audit-level` description in `action.yml`